### PR TITLE
Fixed incorrect syntax highlighting of string literals

### DIFF
--- a/syntaxes/lua.tmLanguage.json
+++ b/syntaxes/lua.tmLanguage.json
@@ -86,7 +86,8 @@
                     "name": "string.quoted.single.lua",
                     "patterns": [
                         {
-                            "include": "#escaped_char"
+                            "match": "\\\\.",
+                            "name": "constant.character.escape.lua"
                         }
                     ]
                 },
@@ -106,7 +107,8 @@
                     "name": "string.quoted.double.lua",
                     "patterns": [
                         {
-                            "include": "#escaped_char"
+                            "match": "\\\\.",
+                            "name": "constant.character.escape.lua"
                         }
                     ]
                 },


### PR DESCRIPTION
My string literals were not highlighted correctly - some problem with the include statement. 